### PR TITLE
Configure SSL listener (optional)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,13 @@ rabbitmq_create_cluster: no
 rabbitmq_cluster_master: localhost
 rabbitmq_vhosts: []
 
+rabbitmq_ssl: no
+rabbitmq_ssl_port: 5671
+rabbitmq_ssl_use_snakeoil_cert: yes
+rabbitmq_ssl_ca_cert:
+rabbitmq_ssl_cert:
+rabbitmq_ssl_key:
+
 rabbitmq_plugins:
   - rabbitmq_management
 

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -1,6 +1,11 @@
 ---
 # Configure RabbitMQ
 
+- name: rabbitmq config file
+  template: src=etc/rabbitmq/rabbitmq.config.j2 dest=/etc/rabbitmq/rabbitmq.config owner=root group=root mode=0644
+  notify: restart rabbitmq-server
+  tags: [configuration,rabbitmq]
+
 - name: rabbitmq default file
   template: src=etc/default/rabbitmq-server.j2 dest=/etc/default/rabbitmq-server owner=root group=root mode=0644
   notify: restart rabbitmq-server

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -6,3 +6,10 @@
   with_items:
     - rabbitmq-server
 
+- name: install ssl-cert
+  apt: pkg=ssl-cert state=present
+  when: rabbitmq_ssl and rabbitmq_ssl_use_snakeoil_cert
+
+- name: add rabbitmq user to the ssl-cert group
+  user: name=rabbitmq append=yes groups=ssl-cert
+  when: rabbitmq_ssl and rabbitmq_ssl_use_snakeoil_cert

--- a/templates/etc/rabbitmq/rabbitmq.config.j2
+++ b/templates/etc/rabbitmq/rabbitmq.config.j2
@@ -1,0 +1,21 @@
+[
+  {rabbit, [
+{% if rabbitmq_ssl %}
+     {ssl_listeners, [{{ rabbitmq_ssl_port }}]},
+     {ssl_options, [
+{% if rabbitmq_ssl_use_snakeoil_cert %}
+        {cacertfile,"/etc/ssl/certs/ssl-cert-snakeoil.pem"},
+        {certfile,"/etc/ssl/certs/ssl-cert-snakeoil.pem"},
+        {keyfile,"/etc/ssl/private/ssl-cert-snakeoil.key"},
+        {verify,verify_none},
+        {fail_if_no_peer_cert,false}]}
+{% else %}
+        {cacertfile,"{{ rabbitmq_ssl_ca_cert }}"},
+        {certfile,"{{ rabbitmq_ssl_cert }}"},
+        {keyfile,"{{ rabbitmq_ssl_key }}"},
+        {verify,verify_peer},
+        {fail_if_no_peer_cert,true}]}
+{% endif %}
+{% endif %}
+   ]}
+].


### PR DESCRIPTION
This adds an option to configure SSL listener with either the standard "snakeoil" certificates, just to encrypt the transport layer, or your own certificates.

The config file is currently not managed by the role, so people might have their own config files. This change would overwrite those. I'm not sure what is the best way to handle that.