### PR TITLE
Adding rabbit use long name as a configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ them are as follows.
 	rabbitmq_users_removed:
 	  - guest
 
+       # Use FQDN
+       rabbitmq_use_longname: 'true'
+
 Examples
 --------
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 rabbitmq
 ======
 
-This role configures RabbitMQ cluster.
+This role configures RabbitMQ cluster. This playbook is derived from alexeymedvedchikov.rabbitmq but adds the ability to use FQDN.
 
 Requirements
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,9 @@ rabbitmq_create_cluster: no
 rabbitmq_cluster_master: localhost
 rabbitmq_use_longname: 'false'
 rabbitmq_vhosts: []
+rabbitmq_ha_enabled: no
+rabbitmq_ha_pattern: ''
+rabbitmq_ha_mode: 'all'
 
 rabbitmq_plugins:
   - rabbitmq_management

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,7 +5,7 @@ rabbitmq_erlang_cookie: 1qa2ws3ed
 rabbitmq_ulimit_open_files: 1024
 rabbitmq_create_cluster: no
 rabbitmq_cluster_master: localhost
-rabbitmq_use_longname: false
+rabbitmq_use_longname: 'false'
 rabbitmq_vhosts: []
 
 rabbitmq_plugins:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ rabbitmq_erlang_cookie: 1qa2ws3ed
 rabbitmq_ulimit_open_files: 1024
 rabbitmq_create_cluster: no
 rabbitmq_cluster_master: localhost
+rabbitmq_use_longname: false
 rabbitmq_vhosts: []
 
 rabbitmq_plugins:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -5,3 +5,8 @@
   template: src=etc/default/rabbitmq-server.j2 dest=/etc/default/rabbitmq-server owner=root group=root mode=0644
   notify: restart rabbitmq-server
   tags: [configuration,rabbitmq]
+
+- name: rabbitmq environment variables
+  template: src=etc/rabbitmq/rabbitmq-env.j2 dest=/etc/rabbitmq/rabbitmq-env.conf owner=root group=root mode=0644
+  notify: restart rabbitmq-server
+  tags: [configuration,rabbitmq]   

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,7 +15,7 @@
 - include: service.yml
 
 - include: cluster.yml
-  when: 'rabbitmq_create_cluster and (ansible_hostname != rabbitmq_cluster_master) and (ansible_fqdn != rabbitmq_cluster_master')
+  when: 'rabbitmq_create_cluster and (ansible_hostname != rabbitmq_cluster_master) and (ansible_fqdn != rabbitmq_cluster_master)'
 
 - include: rabbitmq.yml
   when: 'not rabbitmq_create_cluster or (ansible_hostname == rabbitmq_cluster_master) or (ansible_fqdn != rabbitmq_cluster_master)'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,9 +15,9 @@
 - include: service.yml
 
 - include: cluster.yml
-  when: 'rabbitmq_create_cluster and (ansible_hostname != rabbitmq_cluster_master)'
+  when: 'rabbitmq_create_cluster and (ansible_hostname != rabbitmq_cluster_master) and (ansible_fqdn != rabbitmq_cluster_master')
 
 - include: rabbitmq.yml
-  when: 'not rabbitmq_create_cluster or (ansible_hostname == rabbitmq_cluster_master)'
+  when: 'not rabbitmq_create_cluster or (ansible_hostname == rabbitmq_cluster_master) or (ansible_fqdn != rabbitmq_cluster_master)'
 
 - meta: flush_handlers

--- a/tasks/rabbitmq.yml
+++ b/tasks/rabbitmq.yml
@@ -23,6 +23,10 @@
   with_items: rabbitmq_users
   tags: [configuration,rabbitmq]
 
+- name: ensure the default vhost contains the HA policy
+  rabbitmq_policy: name=HA pattern='{{rabbitmq_ha_pattern}}'' tags="ha-mode={{rabbitmq_ha_mode}"
+  when: rabbitmq_create_cluster and rabbitmq_ha_enabled
+
 - name: Symlink RabbitMQ bin to sbin
   file: state=link src=/usr/lib/rabbitmq/bin dest=/usr/lib/rabbitmq/sbin
   tags: [configuration,rabbitmq]

--- a/tasks/rabbitmq.yml
+++ b/tasks/rabbitmq.yml
@@ -24,7 +24,10 @@
   tags: [configuration,rabbitmq]
 
 - name: ensure the default vhost contains the HA policy
-  rabbitmq_policy: name=HA pattern='{{rabbitmq_ha_pattern}}'' tags="ha-mode={{rabbitmq_ha_mode}"
+  rabbitmq_policy: name=HA pattern='{{ rabbitmq_ha_pattern }}'
+  args:
+   tags:
+    "ha-mode": '{{ rabbitmq_ha_mode }}'
   when: rabbitmq_create_cluster and rabbitmq_ha_enabled
 
 - name: Symlink RabbitMQ bin to sbin

--- a/templates/etc/rabbitmq/rabbitmq-env.j2
+++ b/templates/etc/rabbitmq/rabbitmq-env.j2
@@ -1,0 +1,1 @@
+RABBITMQ_USE_LONGNAME={{ rabbitmq_use_longname }} 


### PR DESCRIPTION
This pull request allows you to set the RABBITMQ_USE_LONGNAME environment variable and hence use FQDN in the cluster rather than short names. 