### PR TITLE
[Fix #11] Update rabbitmq tasks conditional

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,6 @@
   when: 'rabbitmq_create_cluster and (ansible_hostname != rabbitmq_cluster_master) and (ansible_fqdn != rabbitmq_cluster_master)'
 
 - include: rabbitmq.yml
-  when: 'not rabbitmq_create_cluster or (ansible_hostname == rabbitmq_cluster_master) or (ansible_fqdn != rabbitmq_cluster_master)'
+  when: 'not rabbitmq_create_cluster or (ansible_hostname == rabbitmq_cluster_master) or (ansible_fqdn == rabbitmq_cluster_master)'
 
 - meta: flush_handlers


### PR DESCRIPTION
When RabbitMQ is not a cluster, or When `ansible_hostname` is the cluster master or `ansible_fqdn` is the cluster master, then execute the rabbitmq tasks.