### PR TITLE
Doesn't fail if the machine is already part of a cluster

### DIFF
--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -19,8 +19,6 @@
   ignore_errors: True
   tags: rabbitmq
 
-- debug: msg="Join cluster output {{ join_cluster_output }}"
-
 - name: skip fail if the node is already a member of the cluster
   fail: msg="join_cluster failed but node is not already a member"
   when: ("'already_member' not in join_cluster_output.stderr") and

--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -15,7 +15,16 @@
 
 - name: add this node to cluster
   shell: rabbitmqctl join_cluster rabbit@{{ rabbitmq_cluster_master }}
+  register: join_cluster_output
+  ignore_errors: True
   tags: rabbitmq
+
+- debug: msg="Join cluster output {{ join_cluster_output }}"
+
+- name: skip fail if the node is already a member of the cluster
+  fail: msg="join_cluster failed but node is not already a member"
+  when: ("'already_member' not in join_cluster_output.stderr") and
+        (join_cluster_output.rc == 1)
 
 - name: start rabbitmq app
   shell: rabbitmqctl start_app


### PR DESCRIPTION
This PR adds a protection mechanism to cluster.yml. Previously, if a machine needed to join a cluster and was provisioned twice RabbitMQ exited with an error ("already_member"). Now that error does no more make Ansible stop provisioning the machine.