### PR TITLE
Use keyserver instead now

### DIFF
--- a/tasks/repository.yml
+++ b/tasks/repository.yml
@@ -2,7 +2,8 @@
 # Setup installation repositories
 
 - name: import repository key
-  apt_key: url=https://www.rabbitmq.com/rabbitmq-release-signing-key.asc state=present
+  apt_key: keyserver=hkps.pool.sks-keyservers.net id=0x6B73A36E6026DFCA
+
 
 - name: add apt repository
   apt_repository: repo="deb http://www.rabbitmq.com/debian/ testing main"


### PR DESCRIPTION
This does not require ca-certificates and other dependencies like
before, fixing installation on lxc.

We're using this roles in lxc for test instances only.

Thanks !