### PR TITLE
Install management command line tool

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,4 +20,7 @@
 - include: rabbitmq.yml
   when: 'not rabbitmq_create_cluster or (ansible_hostname == rabbitmq_cluster_master) or (ansible_fqdn != rabbitmq_cluster_master)'
 
+- include: rabbitmqadmin.yml
+  when: "'rabbitmq_management' in rabbitmq_plugins"
+
 - meta: flush_handlers

--- a/tasks/rabbitmqadmin.yml
+++ b/tasks/rabbitmqadmin.yml
@@ -1,0 +1,7 @@
+---
+- name: Install management command line tool
+  get_url:
+    url: http://localhost:15672/cli/rabbitmqadmin
+    dest: /usr/local/bin/rabbitmqadmin
+    mode: 0755
+    use_proxy: no


### PR DESCRIPTION
Install `rabbitmqadmin` tool as per https://www.rabbitmq.com/management-cli.html.