### PR TITLE
Fixed installation of multiple plugins

### DIFF
--- a/tasks/rabbitmq.yml
+++ b/tasks/rabbitmq.yml
@@ -35,8 +35,7 @@
   tags: [configuration,rabbitmq]
 
 - name: Enable the plugins is installed
-  rabbitmq_plugin: names="{{ item }}" state=enabled prefix=/usr/lib/rabbitmq
-  with_items: rabbitmq_plugins
+  rabbitmq_plugin: names="{{ rabbitmq_plugins | join(',') }}" state=enabled prefix=/usr/lib/rabbitmq
   notify: restart rabbitmq-server
   tags: [configuration,rabbitmq]
 


### PR DESCRIPTION
The current task is incorrect, per http://docs.ansible.com/ansible/rabbitmq_plugin_module.html the `names` parameters should be the list of the plugins. As is it is now it will only install the last plugin in the list and remove the other ones.