### PR TITLE
Add custom logrotate template

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ them are as follows.
 	# Short hostname of cluster master, on master node it must be specified too
 	rabbitmq_cluster_master: localhost
 
+        # The frequency rotation of log files.
+        rabbitmq_logrotate_period: weekly
+
+        # The number of log files that you want to store.
+        rabbitmq_logrotate_amount: 20
+
 	# Vhosts to create
 	rabbitmq_vhosts: []
 

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ them are as follows.
 	# Short hostname of cluster master, on master node it must be specified too
 	rabbitmq_cluster_master: localhost
 
-        # The frequency rotation of log files.
-        rabbitmq_logrotate_period: weekly
+	# The frequency rotation of log files.
+	rabbitmq_logrotate_period: weekly
 
-        # The number of log files that you want to store.
-        rabbitmq_logrotate_amount: 20
+	# The number of log files that you want to store.
+	rabbitmq_logrotate_amount: 20
 
 	# Vhosts to create
 	rabbitmq_vhosts: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,9 @@ rabbitmq_ssl_ca_cert:
 rabbitmq_ssl_cert:
 rabbitmq_ssl_key:
 
+rabbitmq_logrotate_period: weekly
+rabbitmq_logrotate_amount: 20
+
 rabbitmq_plugins:
   - rabbitmq_management
 

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -13,3 +13,11 @@
 - name: add rabbitmq user to the ssl-cert group
   user: name=rabbitmq append=yes groups=ssl-cert
   when: rabbitmq_ssl and rabbitmq_ssl_use_snakeoil_cert
+
+- name: customize logrotate rules
+  template:
+    src: etc/logrotate.d/rabbitmq-server.j2
+    dest: /etc/logrotate.d/rabbitmq-server
+    owner: root
+    group: root
+    mode: 0644

--- a/templates/etc/logrotate.d/rabbitmq-server.j2
+++ b/templates/etc/logrotate.d/rabbitmq-server.j2
@@ -1,0 +1,12 @@
+/var/log/rabbitmq/*.log {
+        {{ rabbitmq_logrotate_period }}
+        missingok
+        rotate {{ rabbitmq_logrotate_amount }}
+        compress
+        delaycompress
+        notifempty
+        sharedscripts
+        postrotate
+            /etc/init.d/rabbitmq-server rotate-logs > /dev/null
+        endscript
+}


### PR DESCRIPTION
If we need to reduce / increase the number of stored logs - now we can do it.

The basis of the standard template is taken rabbitmq rotation rules file from Ubuntu Trusty.