### PR TITLE
Fix error checking whether node is successfully added to cluster

### DIFF
--- a/tasks/cluster.yml
+++ b/tasks/cluster.yml
@@ -11,6 +11,13 @@
 
 - name: add this node to cluster
   shell: rabbitmqctl join_cluster rabbit@{{ rabbitmq_cluster_master }}
+  register: join_cluster_output
+  ignore_errors: True
+
+- name: skip fail if the node is already a member of the cluster
+  fail: msg="join_cluster failed but node is not already a member"
+  when: ("'already_member' not in join_cluster_output.stderr") and
+        (join_cluster_output.rc != 0)
 
 - name: start rabbitmq app
   shell: rabbitmqctl start_app


### PR DESCRIPTION
When I tried to add a node to the cluster the exist code was 69, which was not properly checked on.

This PR fixes that issue.