### PR TITLE
Creating and removing a temporary file should not count as a change

### DIFF
--- a/tasks/config-cluster.yml
+++ b/tasks/config-cluster.yml
@@ -9,6 +9,7 @@
 
 - name: backup old erlang cookie
   shell: cp -a /var/lib/rabbitmq/.erlang.cookie /var/lib/rabbitmq/.erlang.cookie.old
+  changed_when: false
 
 - name: check if erlang cookie changed and if it is so stopping server
   template:
@@ -34,3 +35,4 @@
   file:
     path: /var/lib/rabbitmq/.erlang.cookie.old
     state: absent
+  changed_when: false


### PR DESCRIPTION
The creation and deletion of the temporary erlan cookie file counts as changes. This file is not part of the system and its tasks should not count as change.