### PR TITLE
Hide passwords from Ansible output

### DIFF
--- a/tasks/rabbitmq.yml
+++ b/tasks/rabbitmq.yml
@@ -21,6 +21,7 @@
     vhost: "{{ item.vhost|default('/') }}"
     tags: "{{ item.tags|default('') }}"
   with_items: "{{ rabbitmq_users }}"
+  no_log: true
   tags: [configuration,rabbitmq]
 
 - name: ensure the default vhost contains the HA policy


### PR DESCRIPTION
Security issue (logs are stored for later analysis, so they should not contain sensitive data)