### PR TITLE
Add vm_memory_high_watermark configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ them are as follows.
 	# Set max open files for rabbit process 
 	rabbitmq_ulimit_open_files: 1024
 
+	# Set the memory threshold at which the flow control is triggered
+	rabbitmq_memory_high_watermark: 0.4
+
 	# Use cluster or no
 	rabbitmq_create_cluster: no
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,7 @@
 rabbitmq_use_upstream_repository: true
 rabbitmq_erlang_cookie: 1qa2ws3ed
 rabbitmq_ulimit_open_files: 1024
+rabbitmq_memory_high_watermark: 0.4
 rabbitmq_create_cluster: no
 rabbitmq_cluster_master: localhost
 rabbitmq_use_longname: 'false'

--- a/templates/etc/rabbitmq/rabbitmq.config.j2
+++ b/templates/etc/rabbitmq/rabbitmq.config.j2
@@ -1,6 +1,7 @@
 [
   {rabbit, [
-{% if rabbitmq_ssl %}
+     {vm_memory_high_watermark, {{ rabbitmq_memory_high_watermark }}}
+{% if rabbitmq_ssl %},
      {ssl_listeners, [{{ rabbitmq_ssl_port }}]},
      {ssl_options, [
 {% if rabbitmq_ssl_use_snakeoil_cert %}


### PR DESCRIPTION
For our environment we need to be able to configure the memory high watermark.

This PR adds this configuration option (with RabbitMQ default of 0.4% of the available RAM)