### PR TITLE
Support rabbitmq_user permission parameter

### DIFF
--- a/tasks/rabbitmq.yml
+++ b/tasks/rabbitmq.yml
@@ -19,6 +19,7 @@
     read_priv: "{{ item.read_priv|default('.*') }}"
     write_priv: "{{ item.write_priv|default('.*') }}"
     vhost: "{{ item.vhost|default('/') }}"
+    permissions: "{{ item.permissions|default(omit) }}"
     tags: "{{ item.tags|default('') }}"
   with_items: "{{ rabbitmq_users }}"
   tags: [configuration,rabbitmq]


### PR DESCRIPTION
We need to use the `permissions` parameter of the [rabbitmq_users module](http://docs.ansible.com/ansible/rabbitmq_vhost_module.html).

This PR adds support for that. Just like the module, the permissions parameter has precedence over (some of) the other parameters.