### PR TITLE
Update signing key to avoid apt warnings

### DIFF
--- a/tasks/repository.yml
+++ b/tasks/repository.yml
@@ -4,7 +4,7 @@
 
 - name: import repository key
   apt_key:
-    url: http://www.rabbitmq.com/rabbitmq-signing-key-public.asc
+    url: https://www.rabbitmq.com/rabbitmq-release-signing-key.asc
     state: present
 
 - name: add apt repository


### PR DESCRIPTION
Related issue: https://github.com/rabbitmq/rabbitmq-server/issues/832