### PR TITLE
fixes init-rc space bug

### DIFF
--- a/tasks/config-cluster.yml
+++ b/tasks/config-cluster.yml
@@ -6,6 +6,7 @@
     dest: /etc/hosts
     line: "{{ hostvars[item]['ansible_default_ipv4']['address'] }} {{ hostvars[item]['ansible_hostname'] }}"
   with_items: "{{ groups['rabbit'] }}" 
+  when: "{{rabbitmq_use_etc_hosts |default(true)}}"
 
 - name: backup old erlang cookie
   shell: cp -a /var/lib/rabbitmq/.erlang.cookie /var/lib/rabbitmq/.erlang.cookie.old

--- a/templates/etc/default/rabbitmq-server.j2
+++ b/templates/etc/default/rabbitmq-server.j2
@@ -9,4 +9,4 @@
 ulimit -n {{ rabbitmq_ulimit_open_files }}
 
 ERL_EPMD_PORT={{ rabbitmq_epmd_port }}
-RABBITMQ_NODE_PORT= {{ rabbitmq_node_port }}
+RABBITMQ_NODE_PORT={{ rabbitmq_node_port }}


### PR DESCRIPTION
initscript of the rabbitmq-server is complaining about the whitespace for `RABBITMQ_NODE_PORT`

```sh
root@node:~# cat /etc/default/rabbitmq-server
# This file is sourced by /etc/init.d/rabbitmq-server. Its primary
# reason for existing is to allow adjustment of system limits for the
# rabbitmq-server process.
#
# Maximum number of open file handles. This will need to be increased
# to handle many simultaneous connections. Refer to the system
# documentation for ulimit (in man bash) for more information.
#
ulimit -n 10240

ERL_EPMD_PORT=4369
RABBITMQ_NODE_PORT= 25672
root@node:~# /etc/init.d/rabbitmq-server stop
/etc/init.d/rabbitmq-server: 12: /etc/default/rabbitmq-server: 25672: not found
```