### PR TITLE
Changing Users' Passwords

### DIFF
--- a/tasks/rabbitmq.yml
+++ b/tasks/rabbitmq.yml
@@ -23,6 +23,7 @@
     vhost: "{{ item.vhost|default('/') }}"
     permissions: "{{ item.permissions|default(omit) }}"
     tags: "{{ item.tags|default('') }}"
+    force: yes
   with_items: "{{ rabbitmq_users }}"
   no_log: true
   tags: [configuration,rabbitmq]


### PR DESCRIPTION
Adds the force: yes option to the command adding RabbitMQ users.

Fixes issue where users' passwords where not being changed after setting
for the first time.

Fixes alexey-medvedchikov/ansible-rabbitmq#42

Signed-off-by: Jason Rogena <jasonrogena@gmail.com>